### PR TITLE
Migrate from master and slave jargon

### DIFF
--- a/accountbook/migrations/0009_auto_20180726_1025.py
+++ b/accountbook/migrations/0009_auto_20180726_1025.py
@@ -16,12 +16,12 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('relation', models.IntegerField(choices=[(0, '소모품'), (1, '구성품')], default=0)),
-                ('master', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='productrelation_relation_master', to='accountbook.Product')),
-                ('slave', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='productrelation_relation_slave', to='accountbook.Product')),
+                ('main', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='productrelation_relation_main', to='accountbook.Product')),
+                ('subordinate', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='productrelation_relation_subordinate', to='accountbook.Product')),
             ],
         ),
         migrations.AlterUniqueTogether(
             name='productrelation',
-            unique_together={('master', 'slave')},
+            unique_together={('main', 'subordinate')},
         ),
     ]

--- a/accountbook/migrations/0010_auto_20180802_1213.py
+++ b/accountbook/migrations/0010_auto_20180802_1213.py
@@ -36,7 +36,7 @@ class Migration(migrations.Migration):
                 ('amount', models.IntegerField(default=0)),
                 ('holdings', models.IntegerField(default=0)),
                 ('price', models.IntegerField(default=0)),
-                ('asset', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='wealth_relation_master', to='accountbook.Product')),
+                ('asset', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='wealth_relation_main', to='accountbook.Product')),
             ],
         ),
         migrations.AlterField(

--- a/accountbook/migrations/0015_auto_20180802_1418.py
+++ b/accountbook/migrations/0015_auto_20180802_1418.py
@@ -93,8 +93,8 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterField(
             model_name='productrelation',
-            name='master',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='productrelation_relation_master', to='accountbook.Product', verbose_name='상위'),
+            name='main',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='productrelation_relation_main', to='accountbook.Product', verbose_name='상위'),
         ),
         migrations.AlterField(
             model_name='productrelation',
@@ -103,7 +103,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterField(
             model_name='productrelation',
-            name='slave',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='productrelation_relation_slave', to='accountbook.Product', verbose_name='하위'),
+            name='subordinate',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='productrelation_relation_subordinate', to='accountbook.Product', verbose_name='하위'),
         ),
     ]

--- a/accountbook/models.py
+++ b/accountbook/models.py
@@ -124,9 +124,9 @@ class ProductRelation(models.Model):
         (COMPONENT, '구성품')
     )
     class Meta:
-        unique_together = (('master', 'slave'),)
-    master = models.ForeignKey(Product, on_delete=models.CASCADE, related_name='%(class)s_relation_master', verbose_name='상위')
-    slave = models.ForeignKey(Product, on_delete=models.CASCADE, related_name='%(class)s_relation_slave', verbose_name='하위')
+        unique_together = (('main', 'subordinate'),)
+    main = models.ForeignKey(Product, on_delete=models.CASCADE, related_name='%(class)s_relation_main', verbose_name='상위')
+    subordinate = models.ForeignKey(Product, on_delete=models.CASCADE, related_name='%(class)s_relation_subordinate', verbose_name='하위')
     relation = models.IntegerField(default=CONSUMABLE, choices=RELATION_CHOICES, verbose_name='유형')
 
 class Package(models.Model):


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.